### PR TITLE
Added code to save group data as a Yaml file 

### DIFF
--- a/group.py
+++ b/group.py
@@ -36,15 +36,13 @@ group = {
 }
 
 # maximum age
-print("The maximum age of the people in the group is:", max({room['age']for name, room in group.items
+print("The maximum age of the people in the group is:", max({name['age']for group, name in group.items()}))
 
 # average (mean) number of relations among members of the group
-relations_person = {len(room['relations']) for name, room in group.items()}
+relations_person = {len(name['relations']) for group, name in group.items()}
 mean = sum(relations_person)/len(relations_person)
 print("The average (mean) number of relations among members of the group:", mean)
 
-
-
-
-
-
+# the maximum age of people in the group that have at least one relation
+print("The maximum age of people in the group that have at least one relation is",
+        max({name['age'] for group, name in group.items() if len(name['relations']) > 0 }))

--- a/group.py
+++ b/group.py
@@ -36,7 +36,13 @@ group = {
 }
 
 # maximum age
-print("The maximum age of the people in the group is:", max({room['age']for name, room in group.items()}))
+print("The maximum age of the people in the group is:", max({room['age']for name, room in group.items
+
+# average (mean) number of relations among members of the group
+relations_person = {len(room['relations']) for name, room in group.items()}
+mean = sum(relations_person)/len(relations_person)
+print("The average (mean) number of relations among members of the group:", mean)
+
 
 
 

--- a/group.py
+++ b/group.py
@@ -2,4 +2,40 @@
 
 # Your code to go here...
 
-my_group =
+my_group = []
+
+class group_member():
+    def __init__(self, name, age, job = "student"):
+            self.name = name
+            self.age = age
+            self.job = job
+            self.relationships = []
+
+    def newRelationship(self, person, connection):
+            self.relationships.append([person, connection])
+
+
+Brendan = group_member("Brendan", 26)
+Kumail = group_member("Kumail", 22)
+Weichao = group_member("Weichao", 22)
+Yuyang = group_member("Yuyang", 22)
+
+my_group.append(Brendan)
+my_group.append(Kumail)
+my_group.append(Weichao)
+my_group.append(Yuyang)
+
+Brendan.newRelationship(Kumail, "classmate")
+
+Jill = group_member("Jill", 26, "biologist")
+Zalika = group_member("Zalika", 28, "artist")
+John = group_member("John", 27, "writer")
+Nash = group_member("Nash", 34, "chef")
+
+Jill.newRelationship(Zalika, "friend")
+Jill.newRelationship(John, "partner")
+Zalika.newRelationship(Jill, "friend")
+John.newRelationship(John, "partner")
+John.newRelationship(Nash, "cousin")
+Nash.newRelationship(John, "cousin")
+Nash.newRelationship(Zalika, "landlord")

--- a/group.py
+++ b/group.py
@@ -51,3 +51,13 @@ print("The maximum age of people in the group that have at least one relation is
 print ("The maximum age of people in the group that have at least one friend is",
         max({name['age'] for group, name in group.items() for relation_name, relation_relation in name['relations'].items() 
         if 'friend' is (relation_relation)}))
+
+
+# writing to a YAML file
+import yaml
+with open('group.yaml', 'w') as yaml_group_out:
+    yaml_group_out.write(yaml.dump(group))
+
+# makng sure the file can be read
+with open('group.yaml') as yaml_group_in:
+    group_again = yaml.safe_load(yaml_group_in)

--- a/group.py
+++ b/group.py
@@ -35,3 +35,10 @@ group = {
     }
 }
 
+# maximum age
+print("The maximum age of the people in the group is:", max({room['age']for name, room in group.items()}))
+
+
+
+
+

--- a/group.py
+++ b/group.py
@@ -1,41 +1,37 @@
 """An example of how to represent a group of acquaintances in Python."""
 
-# Your code to go here...
+# Using the example code from the lecture
 
-my_group = []
+group = {
+    "Jill": {
+        "age": 26,
+        "job": "biologist",
+        "relations": {
+            "Zalika": "friend",
+            "John": "partner"
+        }
+    },
+    "Zalika": {
+        "age": 28,
+        "job": "artist",
+        "relations": {
+            "Jill": "friend"
+        }
+    },
+    "John": {
+        "age": 27,
+        "job": "writer",
+        "relations": {
+            "Jill": "partner"
+        }
+    },
+    "Nash": {
+        "age": 34,
+        "job": "chef",
+        "relations": {
+            "John": "cousin",
+            "Zalika": "landlord"
+        }
+    }
+}
 
-class group_member():
-    def __init__(self, name, age, job = "student"):
-            self.name = name
-            self.age = age
-            self.job = job
-            self.relationships = []
-
-    def newRelationship(self, person, connection):
-            self.relationships.append([person, connection])
-
-
-Brendan = group_member("Brendan", 26)
-Kumail = group_member("Kumail", 22)
-Weichao = group_member("Weichao", 22)
-Yuyang = group_member("Yuyang", 22)
-
-my_group.append(Brendan)
-my_group.append(Kumail)
-my_group.append(Weichao)
-my_group.append(Yuyang)
-
-Brendan.newRelationship(Kumail, "classmate")
-
-Jill = group_member("Jill", 26, "biologist")
-Zalika = group_member("Zalika", 28, "artist")
-John = group_member("John", 27, "writer")
-Nash = group_member("Nash", 34, "chef")
-
-Jill.newRelationship(Zalika, "friend")
-Jill.newRelationship(John, "partner")
-Zalika.newRelationship(Jill, "friend")
-John.newRelationship(John, "partner")
-John.newRelationship(Nash, "cousin")
-Nash.newRelationship(John, "cousin")
-Nash.newRelationship(Zalika, "landlord")

--- a/group.py
+++ b/group.py
@@ -46,3 +46,8 @@ print("The average (mean) number of relations among members of the group:", mean
 # the maximum age of people in the group that have at least one relation
 print("The maximum age of people in the group that have at least one relation is",
         max({name['age'] for group, name in group.items() if len(name['relations']) > 0 }))
+
+# the maximum age of people in the group that have at least one friend (indent for readability)
+print ("The maximum age of people in the group that have at least one friend is",
+        max({name['age'] for group, name in group.items() for relation_name, relation_relation in name['relations'].items() 
+        if 'friend' is (relation_relation)}))

--- a/group.yaml
+++ b/group.yaml
@@ -1,0 +1,22 @@
+Jill:
+  age: 26
+  job: biologist
+  relations:
+    John: partner
+    Zalika: friend
+John:
+  age: 27
+  job: writer
+  relations:
+    Jill: partner
+Nash:
+  age: 34
+  job: chef
+  relations:
+    John: cousin
+    Zalika: landlord
+Zalika:
+  age: 28
+  job: artist
+  relations:
+    Jill: friend


### PR DESCRIPTION
The group.py has now been updated to save the group dictionary as a Yaml file. 

The Yaml file is easier to read (visually), but it causes the entries to be sorted into alphabetical order when reimported. This is not the case for JSON (i think?) 

Answers UCL-RITS/rse-classwork-2020#11